### PR TITLE
Fix failing asciidocify filter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,15 +39,16 @@ asciidoc: {}
 asciidoctor:
   ext: adoc
   safe: 0
-  base_dir: :docdir
+  base_dir: .
   attributes:
     imagesdir: /images
     icons: font
     source-highlighter: highlight.js
     ### paths from topic/ to root files
-    path_to_jekyll_config: ../../_config.yml
-    path_to_readme: ../../README.adoc
-    path_to_data_dir: ../_data
+    topics_path: _docs/topics
+    path_to_jekyll_config: _config.yml
+    path_to_readme: README.adoc
+    path_to_data_dir: _docs/_data
     example-capition: ''
 # end::asciidoctor[]
 

--- a/_docs/landing.adoc
+++ b/_docs/landing.adoc
@@ -1,10 +1,10 @@
 :page-permalink: /
 :page-layout: landing
-include::../README.adoc[tags=globals]
+include::README.adoc[tags=globals]
 = Welcome to AsciiDocsy
 
 [.text-xl-center]
-include::../README.adoc[tags=opener]
+include::README.adoc[tags=opener]
 
 [WARNING.jumbotron-fluid.text-xl-center]
 ====
@@ -39,7 +39,7 @@ If you are looking for a full-featured theme for a Jekyll application with conte
 [discrete]
 === AsciiDocsy's Purpose
 
-include::../README.adoc[tags=purpose]
+include::README.adoc[tags=purpose]
 --
 
 [.jumbotron.jumbotron-fluid.text-center.bg-primary.text-light.shadow.p-3.mb-5]

--- a/_docs/manual-index.adoc
+++ b/_docs/manual-index.adoc
@@ -6,16 +6,3 @@
 :topics_path: topics
 
 :leveloffset: +1
-include::{topics_path}/theme_intro.adoc[]
-
-include::{topics_path}/theme_install_t.adoc[]
-
-include::{topics_path}/theme_frontend-overview.adoc[]
-
-include::{topics_path}/theme_configure_r.adoc[]
-
-include::{topics_path}/theme_configure-search_r.adoc[leveloffset=+1]
-
-// include::{topics_path}/theme_install.adoc[]
-//
-// include::{topics_path}/theme_devops.adoc[]

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,12 +46,12 @@
     <div class="footer-strings col-md-8 text-center">
     {% if footer_str.copyright %}
       <div class="copyright">
-        <p>{{ footer_str.copyright | asciidocifyxme }}</p>
+        <p>{{ footer_str.copyright | asciidocify }}</p>
       </div>
     {% endif %}
     {% if footer_str.madewith %}
       <div class="madewith">
-        <p>{{ footer_str.madewith | asciidocifyxme }}</p>
+        <p>{{ footer_str.madewith | asciidocify }}</p>
       </div>
     {% endif %}
     </div>


### PR DESCRIPTION
It's not clear at all why a documented setting from the same plugin causes a filter provided by that setting to fail, but that's the case here. I have reported this to Asciidoctor project [here](https://github.com/asciidoctor/jekyll-asciidoc/issues/270).

We will surely want to offer the ability to use the document's own directory as the base_dir, so this needs to get fixed, but for now using paths from the source is working.