### PR TITLE
Fix navgoco highlights and semantic term icon/spinner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -346,7 +346,10 @@ semantics:
     role:
       term:
         show:
-          icon: fa fa-info-circle
+          icon:
+            text: fa fa-info-circle
+            tilt: 15
+            spin: true
           spot: "#sidebar-right"
 
 # SERVICES

--- a/_includes/nav-subject-menu.html
+++ b/_includes/nav-subject-menu.html
@@ -5,35 +5,31 @@ Generates #sidebar-left navigation for subject/product
 {% endcomment %} -->
 <ul id="subject-menu" class="nav flex-column">
   {% for item in include.manifest['menu'] %}
-		{% include path-active.liquid href=item.href %}
-    <li class="nav-item open card tier-1 {{parent}}">
+		{% include path-active.liquid href=item.href  kids=item.kids %}
+    <li class="nav-item open card tier-1 {{parent}} {{active}}">
     {% if item.href %}<a href="{{ item.href }}" class="{{active}} {{open}}">{% endif %}
     {{ item.text }}
     {% if item.href %}</a>{% endif %}
-    {% if item.icon or (item.type and site.features.navigation[menuname]['opts']['show_type_icons']) %}
-      {% assign topic_type = site.data.manifest.topic-types | where: "slug",item.type %}
-      <i class="icon {{ item.icon | topic_type.icon }}"></i>
-    {% endif %}
 		<!-- tag::sample-nesting[] -->
     {% if item.kids %}
       <ul>
       {% for topic in item.kids %}
-			  {% include path-active.liquid href=topic.href %}
-        <li class="nav-item {{open}} {{parent}}">
+			  {% include path-active.liquid href=topic.href kids=topic.kids %}
+        <li class="nav-item {{open}} {{parent}} {{active}}">
           <a href="{{ topic.href }}" class="nav-link {{active}} {{open}}">
 						{{ topic.text }}
 					</a>
           {% if topic.kids %}
           <ul>
             {% for subtopic in topic.kids %}
-						  {% include path-active.liquid href=subtopic.href %}
-            <li>
+						  {% include path-active.liquid href=subtopic.href kids=subtopic.kids %}
+            <li class="nav-item {{open}} {{parent}} {{active}}">
               <a href="{{ subtopic.href }}" class="nav-link {{active}}">{{ subtopic.text }}</a>
               {% if subtopic.kids %}
                 <ul>
                   {% for sst in subtopic.kids %}
-                    {% include path-active.liquid href=sst.href %}
-                  <li>
+                    {% include path-active.liquid href=sst.href kids=sst.kids %}
+                  <li class="nav-item {{open}} {{parent}} {{active}}">
                     <a href="{{ sst.href }}" class="nav-link {{active}}">{{ sst.text }}</a>
                   </li>
                   {% endfor %}

--- a/_includes/path-active.liquid
+++ b/_includes/path-active.liquid
@@ -1,14 +1,18 @@
 {% assign page_url = page.url | append: "/" | replace:"//","/" %}
 {% assign link_url = include.href | append: "/" | replace:"//","/" %}
 {% assign page_url_array = page_url | split: "/" %}
-{% assign path_to_page_url  = page_url_array | pop | join: "/" | append: "/" %}
+{% assign path_to_page_url = page_url_array | pop | join: "/" | append: "/" %}
+{% assign ancestry = page_url | slice: 0, link_url.size %}
 {% assign active = "" %}
 {% assign open   = "" %}
 {% assign parent = "" %}
+{% if include.kids %}
+  {% assign parent = "parent" %}
+{% endif %}
 {% if page_url == link_url %}
   {% assign active = "active" %}
   {% assign open = "open" %}
-{% elsif path_to_page_url == link_url %}
+{% elsif ancestry == link_url %}
   {% assign open = "open" %}
-  {% assign parent = "proud" %}
+  {% assign parent = "proud-ancestor" %}
 {% endif %}

--- a/css/asciidocsy.css
+++ b/css/asciidocsy.css
@@ -11,7 +11,7 @@ body {
   font-weight: normal;
 }
 
-.fa-rotate-20 {
+.fa-rotate-15 {
   -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
   -webkit-transform: rotate(15deg);
   -ms-transform: rotate(15deg);
@@ -208,8 +208,13 @@ ul.list-unstyled {
   background-color: {{ site.styles.color.theme }};
 }
 
-#subject-menu li.nav-item.proud {
-  background-color: #99999930
+#subject-menu li.nav-item.proud-ancestor {
+  background-color: #99999940;
+  border-left: 2px solid {{ site.styles.color.theme }};
+}
+
+#subject-menu li.nav-item.open.active.parent {
+  background-color:  #99999960;
 }
 
 .toggle-switcher {

--- a/js/main.js
+++ b/js/main.js
@@ -60,7 +60,7 @@ $( document ).ready(function() {
   // instantiate the Bootstrap JS
   if ($('.term').length) { // nothing happens if there are no terms on the page
     const termsDict = {{ site.data.terms | jsonify }}
-    const icon      = '{{ site.semantics.inline.role.term.show.icon }}'
+    const icon      = '{{ site.semantics.inline.role.term.show.icon.text }}'
     var termsList   = []
     /**
     Scan content for terms and insert data- attrs for
@@ -78,10 +78,16 @@ $( document ).ready(function() {
         if (!termsList.find(t => t.slug == theTerm.slug)) {
           termsList.push(theTerm);
         };
-        $(this).append('<i class="icon ' + icon + ' fa-rotate-20">');
+{% if site.semantics.inline.role.term.show.icon %}
+  {% if site.semantics.inline.role.term.show.icon.tilt %}
+    {% assign rotate = "fa-rotate-" | append: site.semantics.inline.role.term.show.icon.tilt %}
+  {% endif %}
+        $(this).append('<i class="icon ' + icon + ' {{rotate}}">');
+{% endif %}
         $(this).attr('data-toggle', 'popover');
         $(this).attr('data-title', theTerm['term']);
         $(this).attr('data-content', asciidoctor.convert(theTerm['desc'], {doctype: 'inline'}));
+{% if site.semantics.inline.role.term.show.icon.spin %}
         $(this).hover(
           function() {
             $(this).children('i').addClass('fa-spin')
@@ -89,6 +95,7 @@ $( document ).ready(function() {
           function() {
             $(this).children('i').removeClass('fa-spin')
           });
+{% endif %}
       } else {
         $(this).attr('data-error', 'No term entry found');
       };


### PR DESCRIPTION
* Resolves #25, making sense of Navgoco ancestry and highlighting
* Also fixes the absence of optional icons that optionally spin associated with inline semantic terms