### PR TITLE
Split and document search to 2 indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .jekyll-cache
 .jekyll-metadata
 vendor
+_algolia_api_key

--- a/README.adoc
+++ b/README.adoc
@@ -203,6 +203,34 @@ You will find the generated files at `_site/`.
 [TIP]
 Learn more about applying AsciiDocsy to your use case in the link:{theme_docs_www}[Bootstrapping guide].
 
+== Production Environment Details
+
+The demo/docs site included in this repository generates a site at {theme_demo_www}.
+This site is deployed
+
+=== Deploying
+
+The site automatically generates and deploys each time a commit is merged to the `main` branch.
+
+=== Search Indexing
+
+The search indexing procedure is manual at this time, though we will move it to a GitHub Action before long.
+
+There are two indexes: `asciidocsy-pages` and `asciidocsy-topics`.
+Each has its own custom configuration in `_docs/_data/configs/`.
+
+You must have the Admin-only private key to write files to the Algolia index.
+See link:{theme_demo_www}/docs/theme/config/search/algolia#index-settings[Algolia Search Config: Index Settings] for specifics.
+
+The indices must be processed separately.
+Here are the commands:
+
+.Site search
+ bundle exec jekyll algolia --config _config.yml,_docs/_data/configs/search-index-pages.yml
+
+.Subject search
+ bundle exec jekyll algolia --config _config.yml,_docs/_data/configs/search-index-topics.yml
+
 == Contributing
 
 AsciiDocsy is open for contributions.

--- a/_config.yml
+++ b/_config.yml
@@ -167,18 +167,20 @@ features:
       $doc:
         name: Search the site
         desc: Enables users to search all pages in the site, including non-topics
+# tag::search-site-core[]
       show:
-        text: Search the site…
+        text: Search non-docs PAGES…
         spot: "#nav-site"
-        opts:
-          index: asciidocsy
+      meta:
+        index: asciidocsy-pages
+# end::search-site-core[]
     search-subject:
       show:
-        text: Search the docs…
+        text: Search subject TOPICS…
         icon: fa fa-search
         spot: "#sidebar-left" # where this should appear (alt: leftside nav)
-        opts:
-          index: asciidocsy
+      meta:
+        index: asciidocsy-topics
     versioning:
       togglers:
         user-os: # arbitrary toggler name
@@ -360,9 +362,7 @@ services:
     algolia:
 # tag::algolia[]
       application_id: 'SELDDHION6'
-      index_name: asciidocsy
       search_only_api_key: 'b9112b0485d58729c3e7c7b64291cbd9'
-      extensions_to_index: [adoc]
 # end::algolia[]
 
 social:

--- a/_docs/_data/configs/search-index-pages.yml
+++ b/_docs/_data/configs/search-index-pages.yml
@@ -1,0 +1,6 @@
+algolia:
+  application_id: 'SELDDHION6'
+  index_name: asciidocsy-pages
+  extensions_to_index: [adoc,html]
+  files_to_exclude:
+    - _docs/topics/**

--- a/_docs/_data/configs/search-index-topics.yml
+++ b/_docs/_data/configs/search-index-topics.yml
@@ -1,0 +1,6 @@
+algolia:
+  application_id: 'SELDDHION6'
+  index_name: asciidocsy-topics
+  extensions_to_index: [adoc]
+  files_to_exclude:
+    - pages/**

--- a/_docs/topics/theme_config-search-algolia.adoc
+++ b/_docs/topics/theme_config-search-algolia.adoc
@@ -12,7 +12,9 @@ You only start paying when you use certain thresholds of index space or query ba
 
 AsciiDocsy's implementation of Algolia's Jekyll plugin (link:https://github.com/algolia/jekyll-algolia[source]) (link:https://community.algolia.com/jekyll-algolia/getting-started.html[docs]) and instantsearch form (link:https://community.algolia.com/instantsearch.js/documentation/[docs]).
 
-The `site.algolia` object (by default defined in `_config.yml`, but you could move it to an auxiliary config file and <</docs/theme/advanced#,call multiple configs>>).
+== Search Settings
+
+The `site.services.algolia` object, by default defined in `_config.yml`.
 
 .Algolia object in default configuration file
 [source,yaml]
@@ -21,3 +23,58 @@ The `site.algolia` object (by default defined in `_config.yml`, but you could mo
     search:
 include::{path_to_jekyll_config}[tags=algolia]
 ----
+
+Additionally, each search form on your site needs some more data.
+By default the search forms draw this info from objects inside `site.features.actions`, such as `search-site` and `search-subject`.
+These objects need properties for `show.spot` and `meta.index`.
+
+[source,yaml]
+----
+  actions:
+    search-site:
+include::{path_to_jekyll_config}[tags=search-site-core]
+----
+
+[WARNING]
+These settings are only used for _searching_.
+
+[[index-settings]]
+== Index Settings
+
+In order to _index_ your site's content, you will need an auxilliary configuration file with the `algolia` object at the root.
+This configuration file can be called instead of or in addition to the main Jekyll config.
+
+._docs/_data/configs/search-index-pages.yml
+[source,yaml]
+----
+include::_docs/_data/configs/search-index-pages.yml[]
+----
+
+The search is performed by running a `jekyll algolia` operation with your private API key added.
+
+=== ENV Variable
+
+One option is to add your key explicitly to the commandline as an environment variable.
+
+.Example commandline ENV variable option
+ ALGOLIA_API_KEY=01d664977165dbf4cded12199738fabf bundle exec jekyll algolia --config _config.yml,_data/configs/jekyll-search-x.yml
+
+=== Stashed File
+
+Alternatively, stash the key as in a file called `_algolia_api_key` (no file extension).
+
+.Entire contents of file `_algolia_option_key`
+ 01d664977165dbf4cded12199738fabf
+
+[IMPORTANT]
+Be sure to add this file to your [.path]`.gitignore` file.
+
+In this case, you may run simply:name: value
+
+.Example commandline with no ENV variable
+ bundle exec jekyll algolia --config _config.yml,_data/configs/jekyll-search-x.yml`
+
+[TIP]
+To test your indexing process without pushing to Algolia, add [.cmd]`--dry-run` (or simply [.cmd]`-n`)
+
+For full configuration options, refer to the link:https://community.algolia.com/jekyll-algolia/options.html[Jekyll community documentation].

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -3,6 +3,7 @@
 {% assign search-name = include.search %}
 {% assign searchname = include.search | replace:"-","" %}
 {% assign search = site.features.actions[search-name] %}
+{% include hook.liquid template="search-form_html" spot="head" %}
 <script>
 var hrefChanged = false;
 </script>
@@ -26,7 +27,7 @@ $( "#aa-{{ search-name }}-input" ).keydown(function(e) {
 });
 
 var client = algoliasearch('{{ site.services.search.algolia.application_id }}', '{{ site.services.search.algolia.search_only_api_key }}');
-var index = client.initIndex('{{ site.features.actions.search-subject.show.opts.index }}');
+var index = client.initIndex('{{ site.features.actions[search-name].meta.index }}');
 // Initialize autocomplete on search input (ID selector must match).
 autocomplete('#aa-{{ search-name }}-input',
 { hint: true, autoselect: false }, {
@@ -49,7 +50,7 @@ autocomplete('#aa-{{ search-name }}-input',
       empty: function(suggestion) {
         // Add the see more results option when no suggestion is found...
         // just in case the user prefers to search in the main search page.
-        var hrefValue = "search.html?q=" + document.getElementById('aa-{{ search-name }}-input').value.replace(' ', '+');
+        var hrefValue = "/search?q=" + document.getElementById('aa-{{ search-name }}-input').value.replace(' ', '+');
         return '<div class="aa-suggestion" role="option"><a id="show-more-link" class="suggestion-link" href="' + hrefValue + '">See more results...</a></div>';
       },
       footer: function(suggestion) {
@@ -58,7 +59,7 @@ autocomplete('#aa-{{ search-name }}-input',
         if (suggestion.isEmpty){
           return;
         }
-        var hrefValue = "search.html?q=" + document.getElementById('aa-{{ search-name }}-input').value.replace(' ', '+');
+        var hrefValue = "/search?q=" + document.getElementById('aa-{{ search-name }}-input').value.replace(' ', '+');
         return '<div class="aa-suggestion" role="option"><a id="show-more-link" class="suggestion-link" href="' + hrefValue + '">See more results...</a></div>';
       },
       // 'suggestion' templating function used to render a single suggestion.

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -25,7 +25,7 @@ $(document).ready(function() {
   const search = instantsearch({
     appId: '{{ site.services.search.algolia.application_id }}',
     apiKey: '{{ site.services.search.algolia.search_only_api_key }}',
-    indexName: '{{ site.features.actions.search-subject.show.opts.index }}',
+    indexName: '{{ site.features.actions.search-subject.meta.index }}',
     searchParameters: {
       hitsPerPage: 10,
       typoTolerance: false,


### PR DESCRIPTION
* Splits indices
* Creates distinct config files
* Instructs general search indexing in docs
* Instructs AsciiDocsy demo/docs search indexing in Readme

Already performed the cloud-side index split, pushed content to both new indices.